### PR TITLE
Update cros-ec-sensors test due sensorhub driver introduction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ HELPERS := assert_file_is_empty \
 	   bootrr-auto \
 	   bootrr-generic-tests \
 	   ensure_lib_firmware \
+	   kernel_greater_than \
+	   kernel_older_than \
 	   rproc-start \
 	   rproc-stop \
 	   value_in_range \

--- a/boards/google,kevin
+++ b/boards/google,kevin
@@ -41,7 +41,7 @@ assert_driver_present cros-ec-sysfs-driver-present cros-ec-sysfs
 assert_device_present cros-ec-sysfs-probed cros-ec-sysfs cros-ec-sysfs.*
 assert_sysfs_attr_present cros-ec-sysfs-attr-flashinfo /sys/class/chromeos/cros_ec/flashinfo
 assert_sysfs_attr_present cros-ec-sysfs-attr-kb_wake_angle /sys/class/chromeos/cros_ec/kb_wake_angle
-assert_sysfs_attr_present cros-ec-sysfs-attr-veresion /sys/class/chromeos/cros_ec/version
+assert_sysfs_attr_present cros-ec-sysfs-attr-version /sys/class/chromeos/cros_ec/version
 
 assert_driver_present hdmi-audio-codec-driver-present hdmi-audio-codec
 assert_device_present hdmi-audio-codec-probed hdmi-audio-codec hdmi-audio-codec.*

--- a/boards/google,kevin
+++ b/boards/google,kevin
@@ -24,9 +24,18 @@ assert_driver_present cros-ec-rtc-driver-present cros-ec-rtc
 assert_device_present cros-ec-rtc-probed cros-ec-rtc cros-ec-rtc.*
 
 assert_driver_present cros-ec-sensors-driver-present cros-ec-sensors
-assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.0
-assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.1
-assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.0
+if kernel_greater_than "5.4"; then
+    assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.11.*
+    assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.13.*
+    assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.12.*
+
+    assert_driver_present cros-ec-sensorhub-driver-present cros-ec-sensorhub
+    assert_device_present cros-ec-sensorhub-probed cros-ec-sensorhub cros-ec-sensorhub.1.*
+else
+    assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.0
+    assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.1
+    assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.0
+fi
 
 assert_driver_present cros-ec-sysfs-driver-present cros-ec-sysfs
 assert_device_present cros-ec-sysfs-probed cros-ec-sysfs cros-ec-sysfs.*


### PR DESCRIPTION
Since we introduced the sensorhub driver the topology of the sensors changed, so we need to update the tests accordingly. This fixes the following fails on baseline tests for Kevin.

bootrr - 84 tests: 81 PASS, 3 FAIL, 0 SKIP
* cros-ec-sensors-accel0-probed:
never passed
* cros-ec-sensors-accel1-probed:
never passed
* cros-ec-sensors-gyro0-probed:
never passed

While here also fix a small typo.
