### PR TITLE
Install the helpers to check the kernel revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ HELPERS := assert_file_is_empty \
 	   bootrr-auto \
 	   bootrr-generic-tests \
 	   ensure_lib_firmware \
+	   kernel_greater_than \
+	   kernel_older_than \
 	   rproc-start \
 	   rproc-stop \
 	   value_in_range \


### PR DESCRIPTION
Add the kernel_greater_than and kernel_older_than to the list in the
Makefile so they get installed in the file system.

Fixes: 332d44826e44 ("bootrr: Add two helpers to check the running kernel version")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>