### PR TITLE
helpers: bootrr-auto: Add support for ACPI devices

### DIFF
--- a/helpers/bootrr-auto
+++ b/helpers/bootrr-auto
@@ -2,7 +2,15 @@
 
 $(pwd)/helpers/bootrr-generic-tests
 
-for TEST in $(tr "\0" "\n" < /proc/device-tree/compatible); do
+if [ -f "/sys/class/dmi/id/product_name" ]; then
+	vendor="$(cat /sys/class/dmi/id/sys_vendor)"
+	product="$(cat /sys/class/dmi/id/product_name)"
+	BOARD="$(echo ${vendor},${product} | tr '[:upper:]' '[:lower:]')"
+else
+	BOARD="$(tr '\0' '\n' < /proc/device-tree/compatible)"
+fi
+
+for TEST in ${BOARD}; do
 	if [ -x "$(pwd)/boards/${TEST}" ]; then
 		$(pwd)/boards/${TEST}
 	fi


### PR DESCRIPTION
In the same form of device-tree based devices this patch allows us to
run bootrr scripts for ACPI devices, in this case the name of the script
should be in the form "sys_vendor,product_name" got from DMI
(/sys/class/dmi/id/sys_vendor and /sys/class/dmi/id/product_name)

Signed-off-by: Enric Balletbo i Serra <enric.balletbo@collabora.com>