### PR TITLE
Makefile: install google,grunt and google,hana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ HELPERS := assert_file_is_empty \
 	   state_check
 
 BOARDS := arrow,apq8096-db820c \
+	  google,grunt \
+	  google,hana \
 	  google,kevin \
 	  google,pi \
 	  google,veyron-jaq \


### PR DESCRIPTION
Install the board-specific files for the newly added google,grunt and
google,hana boards.

Fixes: 809288b2a1f9 ("boards: Add board script for google,hana")
Fixes: 3e3f5b43953f ("boards: Add board script for google,grunt")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>