### PR TITLE
boards: google,kevin: Fix cros-ec-sensorhub false positive failures

### DIFF
--- a/boards/google,kevin
+++ b/boards/google,kevin
@@ -24,7 +24,7 @@ assert_driver_present cros-ec-rtc-driver-present cros-ec-rtc
 assert_device_present cros-ec-rtc-probed cros-ec-rtc cros-ec-rtc.*
 
 assert_driver_present cros-ec-sensors-driver-present cros-ec-sensors
-if kernel_greater_than "5.4"; then
+if kernel_greater_than "5.5"; then
     assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.11.*
     assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.13.*
     assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.12.*


### PR DESCRIPTION
The patch was testing using LAVA jobs:

Tests  failing on kernel v5.4.59 without applying the patch
* https://lava.collabora.co.uk/results/2723147

Tests passing with kernel v5.4.59 with the patch applied
* https://lava.collabora.co.uk/results/2723166

Tests passing with kernel v5.6.16
* https://lava.collabora.co.uk/results/2723170
