### PR TITLE
Makefile: install all boards and helpers scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,45 +4,16 @@ all:
 
 all-install :=
 
-HELPERS := assert_file_is_empty \
-           assert_device_present \
-           assert_driver_present \
-	   assert_mmc_present \
-	   assert_partition_found \
-	   assert_sysfs_attr_present \
-	   bootrr \
-	   bootrr-auto \
-	   bootrr-generic-tests \
-	   ensure_lib_firmware \
-	   kernel_greater_than \
-	   kernel_older_than \
-	   rproc-start \
-	   rproc-stop \
-	   value_in_range \
-	   state_check
-
-BOARDS := arrow,apq8096-db820c \
-	  google,grunt \
-	  google,hana \
-	  google,kevin \
-	  google,pi \
-	  google,veyron-jaq \
-	  qcom,apq8016-sbc \
-	  qcom,msm8998-mtp \
-	  qcom,sdm845-mtp \
-	  qcom,qcs404-evb \
-	  sony,xperia-castor
-
 define add-scripts
-$(DESTDIR)$(prefix)/$1/$2: $1/$2
+$(DESTDIR)$(prefix)/$1: $1
 	@echo "INSTALL $$<"
 	@install -D -m 755 $$< $$@
 
-all-install += $(DESTDIR)$(prefix)/$1/$2
+all-install += $(DESTDIR)$(prefix)/$1
 endef
 
-$(foreach v,${BOARDS},$(eval $(call add-scripts,boards,$v)))
-$(foreach v,${HELPERS},$(eval $(call add-scripts,helpers,$v)))
+$(foreach v,$(wildcard boards/*),$(eval $(call add-scripts,$v)))
+$(foreach v,$(wildcard helpers/*),$(eval $(call add-scripts,$v)))
 
 install: $(all-install)
 


### PR DESCRIPTION
Rather than listing all the files to install, when in fact all the
files need to be installed, use a wildcard to automatically install
all the scripts in boards/* and helpers/*.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>