### PR TITLE
bootrr-generic-tests: Add test for online cpus

### DIFF
--- a/helpers/assert_cpu_bringup
+++ b/helpers/assert_cpu_bringup
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+. bootrr
+
+TEST_CASE_ID="$1"
+TIMEOUT="${2:-1}"
+
+if [ -z "${TEST_CASE_ID}" ]; then
+	echo "Usage: $0 <test-case-id> [<timeout>]"
+	exit 1
+fi
+
+if [ ! -d /sys/devices/system/cpu/ ]
+then
+	test_report_exit skip
+fi
+
+cd /sys/devices/system/cpu/
+
+timeout ${TIMEOUT} \
+	[ -s offline -a "$(cat online)" = "$(cat possible)" ] && test_report_exit pass
+
+test_report_exit fail

--- a/helpers/bootrr-generic-tests
+++ b/helpers/bootrr-generic-tests
@@ -2,3 +2,4 @@
 
 assert_file_is_empty deferred-probe-empty /sys/kernel/debug/devices_deferred
 
+assert_cpu_bringup all-cpus-are-online


### PR DESCRIPTION
This test uses the generic cpu topology information from
sysfs to determine if all cpus have been succesfully brought
up for use.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>

See [here](https://lava.collabora.co.uk/scheduler/job/3893271#results_145763437) an example failure caught by this test on a Renesas R-Car board with the secondary cpu cluster offline.

Also this is part of fixing [this kernelci-core issues](https://github.com/kernelci/kernelci-core/issues/701)