### PR TITLE
bootrr-generic-tests: Add TPM boot sanity test

### DIFF
--- a/helpers/assert_tpm_bringup
+++ b/helpers/assert_tpm_bringup
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+. bootrr
+
+TEST_CASE_ID="$1"
+TIMEOUT="${2:-10}"
+
+if [ -z "${TEST_CASE_ID}" ]; then
+	echo "Usage: $0 <test-case-id> [<timeout>]"
+	exit 1
+fi
+
+TPM_DEV="/dev/tpm0"
+
+if test -c $TPM_DEV && which tpm2_getcap
+then
+    export TPM2TOOLS_TCTI="device:$TPM_DEV"
+    timeout ${TIMEOUT} tpm2_getcap commands && test_report_exit pass
+else
+    test_report_exit skip
+fi
+
+test_report_exit fail

--- a/helpers/bootrr-generic-tests
+++ b/helpers/bootrr-generic-tests
@@ -3,3 +3,5 @@
 assert_file_is_empty deferred-probe-empty /sys/kernel/debug/devices_deferred
 
 assert_cpu_bringup all-cpus-are-online
+
+assert_tpm_bringup tpm-chip-is-online


### PR DESCRIPTION
This adds a new simple smoke test to verify TPM chip
communication by querrying any commands it exposes via
an implementation provided by the tpm2-tools project.

More in-depth TPM functionality testing than this smoke
test should be done via the respective devices software,
for e.g. ChromeOS has its own custom userspace TPM stack
which can be exercised via the TAST test framework.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>

[Here is an example run](https://lava.collabora.co.uk/results/testcase/170445026) of this test on Octopus.

A separate pull request to enable the relevant kernel configs and install tpm2-tools in rootfs will be created soon.