### PR TITLE
Fix deferred-probe-empty test

### DIFF
--- a/helpers/assert_file_is_empty
+++ b/helpers/assert_file_is_empty
@@ -16,6 +16,6 @@ then
 	test_report_exit skip
 fi
 
-timeout ${TIMEOUT} [ -n "$(cat "${FILEPATH}")" ] || test_report_exit pass
+timeout ${TIMEOUT} [ -z "$(cat "${FILEPATH}")" ] || test_report_exit fail
 
-test_report_exit fail
+test_report_exit pass

--- a/helpers/assert_file_is_empty
+++ b/helpers/assert_file_is_empty
@@ -16,6 +16,7 @@ then
 	test_report_exit skip
 fi
 
+timeout ${TIMEOUT} cat "${FILEPATH}" || test_report_exit fail
 timeout ${TIMEOUT} [ -z "$(cat "${FILEPATH}")" ] || test_report_exit fail
 
 test_report_exit pass

--- a/helpers/assert_file_is_empty
+++ b/helpers/assert_file_is_empty
@@ -16,6 +16,6 @@ then
 	test_report_exit skip
 fi
 
-timeout ${TIMEOUT} [ -s "${FILEPATH}" ] || test_report_exit pass
+timeout ${TIMEOUT} [ -n "$(cat "${FILEPATH}")" ] || test_report_exit pass
 
 test_report_exit fail


### PR DESCRIPTION
The `deferred-probe-empty` test turns out to not be working, since it checks for the file size (which doesn't work in this case) instead of actual contents. This PR fixes the issue, while also adding a dump of the file contents to make the test log more useful when it fails.

This log shows how the current `deferred-probe-empty` test passes even when a manual `cat` of the `devices_deferred` shows there's clearly content to the file: https://lava.collabora.co.uk/scheduler/job/6757072

Log with the changes in this PR applied: https://lava.collabora.co.uk/scheduler/job/6767602

Expect baseline test cases to fail with this PR (as this test starts to actually work).

This PR depends on #18, otherwise the file contents get split into separate arguments and `sh: platform:: unknown operand` shows up in the log.