### PR TITLE
helpers: Prevent timeout function from splitting arguments in command

### DIFF
--- a/helpers/bootrr
+++ b/helpers/bootrr
@@ -2,11 +2,10 @@
 
 timeout() {
 	attempts="$1"; shift
-	cmd="$@"
 
 	for i in `seq ${attempts}`
 	do
-		$cmd && return 0 
+		"$@" && return 0
 		sleep 1
 	done
 


### PR DESCRIPTION
The timeout function receives a command to run as its arguments, but
when it copies them to a different variable with the syntax cmd="$@", it
also joins all arguments into a string, effectively discarding the
quoting of the arguments in the command.

As an example, `timeout $TIMEOUT foo "bar baz"`, which should run
command "foo" with argument "bar baz", instead runs "foo" with two
arguments, "bar" and "baz". Since we want the timeout function to run
the commands exactly as they were passed, use the $@ variable directly
instead of copying it. The only drawback is that this makes the code
slightly less clear.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>

This bug was noticed while implementing #17.

@gctucker Let me know if you'd prefer to have this commit as part of #17. I decided to open a separate PR for this because it is a standalone fix and has potentially more implications than just the deferred-probe-empty test. If this change breaks any other test, then it was written with a workaround to this bug and the test should be fixed.