### PR TITLE
helpers: Use right argument number for timeout

### DIFF
--- a/helpers/assert_driver_present
+++ b/helpers/assert_driver_present
@@ -4,7 +4,7 @@
 
 TEST_CASE_ID="$1"
 DRIVER="$2"
-TIMEOUT="${4:-1}"
+TIMEOUT="${3:-1}"
 
 if [ -z "${TEST_CASE_ID}" -o -z "${DRIVER}" ]; then
 	echo "Usage: $0 <test-case> <driver> [<timeout>]"

--- a/helpers/assert_file_is_empty
+++ b/helpers/assert_file_is_empty
@@ -4,7 +4,7 @@
 
 TEST_CASE_ID="$1"
 FILEPATH="$2"
-TIMEOUT="${4:-1}"
+TIMEOUT="${3:-1}"
 
 if [ -z "${TEST_CASE_ID}" -o -z "${FILEPATH}" ]; then
 	echo "Usage: $0 <test-case-id> <file path> [<timeout>]"


### PR DESCRIPTION
Some helpers were using the wrong argument number for the timeout
argument. Change them to use the right number.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>

I don't think we're even using any timeout currently, but I noticed this issue so took the opportunity to fix it.