### PR TITLE
Do not check for ID in the device name

### DIFF
--- a/boards/google,kevin
+++ b/boards/google,kevin
@@ -24,18 +24,15 @@ assert_driver_present cros-ec-rtc-driver-present cros-ec-rtc
 assert_device_present cros-ec-rtc-probed cros-ec-rtc cros-ec-rtc.*
 
 assert_driver_present cros-ec-sensors-driver-present cros-ec-sensors
-if kernel_greater_than "5.5"; then
-    assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.11.*
-    assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.13.*
-    assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.12.*
 
+if kernel_greater_than "5.5"; then
     assert_driver_present cros-ec-sensorhub-driver-present cros-ec-sensorhub
-    assert_device_present cros-ec-sensorhub-probed cros-ec-sensorhub cros-ec-sensorhub.1.*
-else
-    assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.0
-    assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.1
-    assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.0
+    assert_device_present cros-ec-sensorhub-probed cros-ec-sensorhub cros-ec-sensorhub.*
 fi
+
+assert_device_present cros-ec-sensors-accel0-probed cros-ec-sensors cros-ec-accel.*
+assert_device_present cros-ec-sensors-accel1-probed cros-ec-sensors cros-ec-accel.*
+assert_device_present cros-ec-sensors-gyro0-probed cros-ec-sensors cros-ec-gyro.*
 
 assert_driver_present cros-ec-sysfs-driver-present cros-ec-sysfs
 assert_device_present cros-ec-sysfs-probed cros-ec-sysfs cros-ec-sysfs.*

--- a/boards/google,kevin
+++ b/boards/google,kevin
@@ -76,7 +76,8 @@ assert_device_present rockchip-emmc-phy-probed rockchip-emmc-phy ff770000.*
 
 assert_driver_present rockchip-i2s-driver-present rockchip-i2s
 assert_device_present rockchip-i2s0-probed rockchip-i2s ff880000.*
-assert_device_present rockchip-i2s1-probed rockchip-i2s ff8a0000.*
+
+assert_device_present rockchip-spdif1-probed rockchip-spdif ff870000.*
 
 assert_driver_present rockchip-iodomain-driver-present rockchip-iodomain
 assert_device_present rockchip-iodomain0-probed rockchip-iodomain ff320000.*


### PR DESCRIPTION
The ID used in the device name for cros-ec drivers keeps changing and has no guarantee to remain stable across different kernel versions. Hence, do not check for ID in the device name.

Signed-off-by: Shreeya Patel <shreeya.patel@collabora.com>