### PR TITLE
helpers: Fix bashism in cpufreq and cpuidle tests

### DIFF
--- a/helpers/assert_cpufreq_enabled
+++ b/helpers/assert_cpufreq_enabled
@@ -14,6 +14,6 @@ CPU=0
 
 while [  $CPU -le $NUM_CPUS ]; do
 	[ -f /sys/devices/system/cpu/cpu${CPU}/cpufreq/scaling_driver ] || test_report_exit fail
-	let CPU=CPU+1
+	CPU=$(expr ${CPU} + 1)
 done
 test_report_exit pass

--- a/helpers/assert_cpuidle_enabled
+++ b/helpers/assert_cpuidle_enabled
@@ -14,6 +14,6 @@ CPU=0
 
 while [  $CPU -le $NUM_CPUS ]; do
 	[ -d /sys/devices/system/cpu/cpu${CPU}/cpuidle ] || test_report_exit fail
-	let CPU=CPU+1
+	CPU=$(expr ${CPU} + 1)
 done
 test_report_exit pass


### PR DESCRIPTION
The helpers for verifiying that cpufreq and cpuidle are enabled use let which is a bash extension and not supported in standard POSIX shell, including with busybox.  Convert to use expr which is standard.

Signed-off-by: Mark Brown <broonie@kernel.org>