### PR TITLE
boards: Move generic RK3288 description to a separate file

### DIFF
--- a/boards/google,veyron-jaq
+++ b/boards/google,veyron-jaq
@@ -42,9 +42,6 @@ assert_device_present ehci-platform-usb_host0_ehci-probed ehci-platform ff500000
 assert_driver_present ramoops-driver-present ramoops
 assert_device_present ramoops-probed ramoops 7fedc000.*
 
-assert_driver_present rk3288-crypto-driver-present rk3288-crypto
-assert_device_present rk3288-crypto-probed rk3288-crypto ff8a0000.*
-
 assert_driver_present rk3x-i2c-driver-present rk3x-i2c
 assert_device_present rk3x-i2c0-probed rk3x-i2c ff650000.*
 assert_device_present rk3x-i2c1-probed rk3x-i2c ff140000.*
@@ -69,9 +66,6 @@ assert_device_present rockchip-i2s-probed rockchip-i2s ff890000.*
 assert_driver_present rockchip-iodomain-driver-present rockchip-iodomain
 assert_device_present rockchip-iodomain-grf-probed rockchip-iodomain ff770000.*
 
-assert_driver_present rockchip-pm-domain-driver-present rockchip-pm-domain
-assert_device_present rockchip-pm-domain-pmu-probed rockchip-pm-domain ff730000.*
-
 assert_driver_present rockchip-pwm-driver-present rockchip-pwm
 assert_device_present rockchip-pwm0-probed rockchip-pwm ff680000.*
 assert_device_present rockchip-pwm1-probed rockchip-pwm ff680010.*
@@ -89,7 +83,3 @@ assert_device_present rockchip-usb-phy-grf-probed rockchip-usb-phy ff770000.*
 assert_driver_present rockchip-vop-driver-present rockchip-vop
 assert_device_present rockchip-vopb-probed rockchip-vop ff930000.*
 assert_device_present rockchip-vopl-probed rockchip-vop ff940000.*
-
-assert_driver_present sram-driver-present sram
-assert_device_present sram-probed sram ff720000.*
-

--- a/boards/rockchip,rk3288
+++ b/boards/rockchip,rk3288
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+assert_driver_present rk3288-crypto-driver-present rk3288-crypto
+assert_device_present rk3288-crypto-probed rk3288-crypto ff8a0000.*
+
+assert_driver_present rockchip-pm-domain-driver-present rockchip-pm-domain
+assert_device_present rockchip-pm-domain-pmu-probed rockchip-pm-domain ff730000.*
+
+assert_driver_present sram-driver-present sram
+assert_device_present sram-probed sram ff720000.*


### PR DESCRIPTION
There are a number of devices on the RK3288 which are usable on and enabled for any system using the SoC, due to either being essential for system operation or entirely internal to the SoC (like the crypto engine).  Move these to a separate script identified by the compatible for the SoC so that we get coverage of these things on any system which uses this SoC.

Signed-off-by: Mark Brown <broonie@kernel.org>