### PR TITLE
boards: google,spherion: Update driver name for clk-mt8192-apmixedsys

### DIFF
--- a/boards/google,spherion
+++ b/boards/google,spherion
@@ -11,7 +11,11 @@ assert_driver_present clk-mt8192-driver-present clk-mt8192
 assert_device_present clk-mt8192-topckgen-probed clk-mt8192 10000000.*
 assert_device_present clk-mt8192-infracfg-probed clk-mt8192 10001000.*
 assert_device_present clk-mt8192-pericfg-probed clk-mt8192 10003000.*
-assert_device_present clk-mt8192-apmixedsys-probed clk-mt8192 1000c000.*
+if kernel_greater_than "6.3"; then
+	assert_device_present clk-mt8192-apmixedsys-probed clk-mt8192-apmixed 1000c000.*
+else
+	assert_device_present clk-mt8192-apmixedsys-probed clk-mt8192 1000c000.*
+fi
 
 assert_driver_present clk-mt8192-aud-driver-present clk-mt8192-aud
 assert_device_present clk-mt8192-aud-probed clk-mt8192-aud 11210000.*


### PR DESCRIPTION
Following "clk: mediatek: mt8192: Move apmixedsys clock driver to its own file" [1], the driver name for the apmixedsys clock on mt8192 became clk-mt8192-apmixed. Update the test accordingly.

[1] https://lore.kernel.org/all/20230221115549.360132-48-angelogioacchino.delregno@collabora.com/

Creating this as a draft since the commit hasn't been merged yet. Even when it's merged, the test will still keep failing in next until the 6.4 release cycle comes around.

Note: it's not possible to make the check accept both names by globbing (ie `clk-mt8192*`) since that produces multiple results, which breaks the syntax for `test`.