### PR TITLE
Introduce USB device probe helper

### DIFF
--- a/boards/google,spherion
+++ b/boards/google,spherion
@@ -254,9 +254,7 @@ assert_driver_present panfrost-driver-present panfrost
 assert_device_present panfrost-probed panfrost 13000000.*
 
 # Camera
-assert_driver_present uvcvideo-driver-present uvcvideo
-assert_device_present uvcvideo0-probed uvcvideo 1-1.4.1:1.0
-assert_device_present uvcvideo1-probed uvcvideo 1-1.4.1:1.1
+assert_usb_probed usb-camera-probed 1 \* \* \* \* \* \* 0e 01 00 \*
 
 # Audio
 assert_driver_present mt8192-audio-driver-present mt8192-audio
@@ -275,9 +273,7 @@ assert_driver_present mt8192_mt6359-driver-present mt8192_mt6359
 assert_device_present mt8192_mt6359-probed mt8192_mt6359 sound
 
 # Bluetooth
-assert_driver_present btusb-driver-present btusb
-assert_device_present btusb0-probed btusb 1-1.4.2:1.0
-assert_device_present btusb1-probed btusb 1-1.4.2:1.1
+assert_usb_probed bluetooth-probed 1 \* \* \* \* \* \* e0 01 01 00
 
 # Watchdog
 assert_driver_present mtk-wdt-driver-present mtk-wdt

--- a/helpers/assert_usb_probed
+++ b/helpers/assert_usb_probed
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+. bootrr
+
+TEST_CASE_ID="$1"
+COUNT="$2"
+VENDOR="$3"
+PRODUCT="$4"
+DEVICE="$5"
+DEV_CLASS="$6"
+DEV_SUBCLASS="$7"
+DEV_PROTOCOL="$8"
+INTF_CLASS="$9"
+INTF_SUBCLASS="${10}"
+INTF_PROTOCOL="${11}"
+INTF_NUM="${12}"
+
+if [ -z "${TEST_CASE_ID}" -o -z "${COUNT}" -o -z "${VENDOR}" ]; then
+	echo "Usage: $0 <test-case-id> <count> <vendor> [<product> <device> <device-class> <device-subclass> <device-protocol> <interface-class> <interface-subclass> <interface-protocol> <interface-number>]"
+	echo "Note: '*' can be used as wildcard for any field"
+	exit 1
+fi
+
+match()
+{
+	FILE="$1"
+	ID="$2"
+
+	[ ! -f "$FILE" ] && return 1
+	[ "$ID" = "*" -o "$ID" = "" ] && return 0
+	[ $(cat "$FILE") != "$ID" ] && return 1
+	return 0
+}
+
+cur_count=0
+
+for dev in $(find /sys/bus/usb/devices -maxdepth 1); do
+	match "$dev"/idVendor "$VENDOR" || continue
+	match "$dev"/idProduct "$PRODUCT" || continue
+	match "$dev"/bcdDevice "$DEVICE" || continue
+	match "$dev"/bDeviceClass "$DEV_CLASS" || continue
+	match "$dev"/bDeviceSubClass "$DEV_SUBCLASS" || continue
+	match "$dev"/bDeviceProtocol "$DEV_PROTOCOL" || continue
+
+	# Matched device. Now search through interfaces
+	for intf in $(find "$dev"/ -maxdepth 1 -type d); do
+		match "$intf"/bInterfaceClass "$INTF_CLASS" || continue
+		match "$intf"/bInterfaceSubClass "$INTF_SUBCLASS" || continue
+		match "$intf"/bInterfaceProtocol "$INTF_PROTOCOL" || continue
+		match "$intf"/bInterfaceNumber "$INTF_NUM" || continue
+
+		# Matched interface. Add to count if it was probed by driver.
+		[ -d "$intf"/driver ] && cur_count=$((cur_count+1))
+	done
+done
+
+if [ "$cur_count" -eq "$COUNT" ]; then
+	test_report_exit pass
+else
+	test_report_exit fail
+fi


### PR DESCRIPTION
Current bootrr helpers, assert_device_present and assert_driver_present,
use driver and device names, both of which are not part of the kernel's
stable ABI and end up requiring extra maintenance whenever those names
are changed, in order to check for the expected name on each kernel
version.

Introduce a new helper, assert_usb_probed, that verifies a USB device
has been probed, taking as parameters the device's hardware identifying
properties, which are documented kernel ABI: idVendor, idProduct,
bcdDevice, bDeviceClass, bDeviceSubClass, bDeviceProtocol,
bInterfaceClass, bInterfaceSubClass, bInterfaceProtocol,
bInterfaceNumber.

A 'count' parameter is also required, to inform the number of devices
matching these criteria that should have been probed. This allows the
test to verify the probe of multiple identical devices.

A '*' can be used as wildcard for any of the matching fields as
necessary.

As part of this PR, the USB devices on Spherion are converted to use this new helper. Other platforms should also be converted over time.

Note: I have a series on the kernel mailing list that adds a kselftest to check for probed devices based on the Devicetree: https://lore.kernel.org/all/20230828211424.2964562-1-nfraprado@collabora.com . That should make most of the `assert_device_present` and `assert_driver_present` tests in bootrr unnecessary. The exception being devices from discoverable busses, like USB and PCI. Hence this PR improves the stability of the checks for USB devices, and I intend to create a similar PR for a check for PCI devices.